### PR TITLE
Skip files with unsupported mode, print a warning instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Directory Checksum
 
-![Coverage](https://img.shields.io/badge/Coverage-92.7%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-83.2%25-brightgreen)
 ![CI](https://github.com/MShekow/directory-checksum/actions/workflows/ci.yml/badge.svg)
 ![CD](https://github.com/MShekow/directory-checksum/actions/workflows/cd.yml/badge.svg)
 

--- a/directory_checksum/fs_scanner.go
+++ b/directory_checksum/fs_scanner.go
@@ -91,7 +91,7 @@ func ScanDirectory(absoluteRootPath string, filesystemImpl afero.Fs) (*Directory
 			}
 
 			if isInvalidFiletype(info.Mode()) {
-				fmt.Printf("Skipping %s because it is of unsupported type: %s", relativePath,
+				fmt.Printf("WARNING: skipping '%s' because it is of unsupported type: %s\n", relativePath,
 					getInvalidFiletypeAsString(info.Mode()))
 				return nil
 			}

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"os"
 )
 
-const version = "1.3"
+const version = "1.4"
 
 var maxDepth int
 


### PR DESCRIPTION
Fixes #6 