### PR TITLE
CI: use staticcheck-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
 
       - uses: dominikh/staticcheck-action@v1.3.1
         with:
-          version: "2023.1.3"
           install-go: false
 
       - name: Run tests


### PR DESCRIPTION
The more recent versions add support
for new Go versions, and fixes
some crashes.